### PR TITLE
Unmask sigsys for other signals

### DIFF
--- a/src/log.cc
+++ b/src/log.cc
@@ -17,17 +17,23 @@
 #include <sys/syscall.h>
 #include <cstring>
 #include <unistd.h>
+#include <cstdarg>
+#include <cstdio>  
 
 #include "log.hh"
 #include "syscall.hh"
 
-void sysfail::log(const char* msg) {
-    syscall(STDERR_FILENO, (long)(msg), strlen(msg), 0, 0, 0, SYS_write);
-}
 
-void sysfail::log(const char* msg, long arg1) {
-    const int len = 256;
-    char buffer[256];
-    int n = snprintf(buffer, sizeof(buffer), msg, arg1);
+void sysfail::log(const char* msg, ...) {
+    const int len = 512;
+    char buffer[len];
+    va_list args;
+    va_start(args, msg);
+    int n = vsnprintf(buffer, sizeof(buffer), msg, args);
+    va_end(args);
+    // Ensure the write length does not exceed the buffer size
+    if (n > len) {
+        n = len;
+    }
     syscall(STDERR_FILENO, (long)(buffer), n, 0, 0, 0, SYS_write);
 }

--- a/src/log.hh
+++ b/src/log.hh
@@ -18,8 +18,7 @@
 #define _LOG_HH
 
 namespace sysfail {
-    void log(const char* msg);
-    void log(const char* msg, long arg1);
+    void log(const char* msg, ...);
 }
 
 #endif

--- a/src/session.cc
+++ b/src/session.cc
@@ -100,7 +100,7 @@ sysfail::ActiveSession::ActiveSession(
     AddrRange&& _self_addr
 ) : plan(_plan), self_text(_self_addr) {
     for(int i=1;i<NSIG;i++) {
-        if(i == SIGKILL or i == SIGSTOP or i == SIGRTMIN or i == SIGRTMAX) continue;
+        if(i == SIGKILL or i == SIGSTOP) continue;
         unmask_sigsys(i);
     }
     enable_handler(SIGSYS, handle_sigsys);

--- a/src/session.cc
+++ b/src/session.cc
@@ -390,7 +390,15 @@ static void sysfail::handle_sigsys(int sig, siginfo_t *info, void *ucontext) {
                 }
             }
         } else if (syscall == SYS_rt_sigreturn) {
-            // TODO handle sigreturn correctly, may be write a test for it?
+             auto rax = set_rsp_and_exec_syscall(
+                     ctx->uc_mcontext.gregs[REG_RDI],
+                     ctx->uc_mcontext.gregs[REG_RSI],
+                     ctx->uc_mcontext.gregs[REG_RDX],
+                     ctx->uc_mcontext.gregs[REG_R10],
+                     ctx->uc_mcontext.gregs[REG_R8],
+                     ctx->uc_mcontext.gregs[REG_R9],
+                     ctx->uc_mcontext.gregs[REG_RAX],
+                     ctx->uc_mcontext.gregs[REG_RSP]);
         } else if (s && syscall != SYS_exit) {
             s->fail_maybe(ctx);
         } else {

--- a/src/syscall.cc
+++ b/src/syscall.cc
@@ -48,3 +48,40 @@ long sysfail::syscall(
 
     return rax;
 }
+
+
+long sysfail::set_rsp_and_exec_syscall(
+    uint64_t arg1, // %rdi
+    uint64_t arg2, // %rsi
+    uint64_t arg3, // %rdx
+    uint64_t arg4, // %rcx
+    uint64_t arg5, // %r8
+    uint64_t arg6, // %r9
+    Syscall syscall,
+    uint64_t rsp
+) {
+    register long rax asm("rax") = syscall;
+    register long rdi asm("rdi") = arg1;
+    register long rsi asm("rsi") = arg2;
+    register long rdx asm("rdx") = arg3;
+    register long r10 asm("r10") = arg4; // kernel uses r10 in place of rcx
+    register long r8 asm("r8") = arg5;
+    register long r9 asm("r9") = arg6;
+
+    asm volatile(
+        "mov %1, %%rsp \n"
+        "syscall \n"
+        : "=a"(rax),
+          "=m"(rsp)
+        : "a"(rax),
+          "D"(rdi),
+          "S"(rsi),
+          "d"(rdx),
+          "r"(r10),
+          "r"(r8),
+          "r"(r9)
+        : "rcx", "r11", "memory"
+    );
+
+    return rax;
+}

--- a/src/syscall.hh
+++ b/src/syscall.hh
@@ -29,6 +29,16 @@ namespace sysfail {
         uint64_t arg6, // %r9
         Syscall syscall
     );
+    long set_rsp_and_exec_syscall(
+            uint64_t arg1, // %rdi
+            uint64_t arg2, // %rsi
+            uint64_t arg3, // %rdx
+            uint64_t arg4, // %rcx
+            uint64_t arg5, // %r8
+            uint64_t arg6, // %r9
+            Syscall syscall,
+            uint64_t rsp
+     );
 }
 
 #endif


### PR DESCRIPTION
Includes three commits
1. Unmask sigsys for other signal handlers.
2. Handle sigreturn in session.cc
3. A change in the go library to make a syscall eligible only if it's a regular file (not network sockets, etc.)